### PR TITLE
Add cold agent support and SIP complaint tracking

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -14,6 +14,8 @@ const defaultData = {
   users: [],
   applications: [],
   admins: [],
+  coldProfiles: [],
+  complaints: [],
 };
 
 const clone = (value) =>


### PR DESCRIPTION
## Summary
- add storage and repository support for cold agent profiles and persisted complaints
- enhance the bot with cold agent menus, admin workflows, and sticker prompts for applications and complaints
- track complaint status updates to build SIP statistics in the admin dashboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dd78f2028883288df24ddfbe29ea97