### PR TITLE
Remove optional chaining usage for older Node support

### DIFF
--- a/src/repository.js
+++ b/src/repository.js
@@ -105,14 +105,16 @@ async function upsertUser(userPayload) {
       status: userPayload.status || 'pending',
       lineIds: userPayload.lineIds || [],
       mutedUntil: null,
-      language: userPayload.language ?? null,
+      language:
+        userPayload.language === undefined ? null : userPayload.language,
       createdAt: now(),
       updatedAt: now(),
     };
     db.data.users.push(user);
   } else {
     Object.assign(user, {
-      username: userPayload.username ?? user.username,
+      username:
+        userPayload.username === undefined ? user.username : userPayload.username,
       firstName:
         userPayload.first_name || userPayload.firstName || user.firstName,
       lastName: userPayload.last_name || userPayload.lastName || user.lastName,


### PR DESCRIPTION
## Summary
- add helper utilities to safely read nested values and coalesce defaults in the bot
- replace optional chaining usages with explicit guards throughout the bot logic
- update repository user upsert logic to avoid nullish coalescing

## Testing
- npm run start *(fails: request to Telegram API due to ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_68dd7f9792bc8328a3f1f259231fa258