### PR TITLE
Ensure compatibility with Node 12 runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,51 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dotenv": "^17.2.3",
-        "lowdb": "^6.1.1",
-        "nanoid": "^5.1.6",
-        "telegraf": "^4.16.3"
+        "dotenv": "^16.4.5",
+        "nanoid": "^3.3.7",
+        "telegraf": "^3.38.0"
       }
-    },
-    "node_modules/@telegraf/types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
-      "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
-      "license": "MIT"
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "license": "MIT"
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -73,9 +32,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -84,38 +43,20 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/lowdb": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-6.1.1.tgz",
-      "integrity": "sha512-HO13FCxI8SCwfj2JRXOKgXggxnmfSc+l0aJsZ5I34X3pwzG/DPBSKyKu3Zkgg/pNmx854SVgE2la0oUeh6wzNw==",
-      "license": "MIT",
-      "dependencies": {
-        "steno": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
       "funding": {
-        "url": "https://github.com/sponsors/typicode"
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+    "node_modules/module-alias": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
+      "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -124,9 +65,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
-      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
@@ -135,10 +76,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.js"
+        "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
-        "node": "^18 || >=20"
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/node-fetch": {
@@ -161,24 +102,6 @@
         }
       }
     },
-    "node_modules/p-timeout": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/safe-compare": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
-      "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc": "^1.2.0"
-      }
-    },
     "node_modules/sandwich-stream": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
@@ -188,44 +111,36 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/steno": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/steno/-/steno-3.2.0.tgz",
-      "integrity": "sha512-zPKkv+LqoYffxrtD0GIVA08DvF6v1dW02qpP5XnERoobq9g3MKcTSBTi08gbGNFMNRo3TQV/6kBw811T1LUhKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
     "node_modules/telegraf": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
-      "integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-3.40.0.tgz",
+      "integrity": "sha512-wulVjRHrX2zQwbk1/jzg3Ll9Kr0xC7ofXsRPJgcV2yoCFx5oSU41ZaDKNRPsLhjXxW4s9iNM2S2N/ESyiZxTMQ==",
       "license": "MIT",
       "dependencies": {
-        "@telegraf/types": "^7.1.0",
-        "abort-controller": "^3.0.0",
-        "debug": "^4.3.4",
-        "mri": "^1.2.0",
-        "node-fetch": "^2.7.0",
-        "p-timeout": "^4.1.0",
-        "safe-compare": "^1.1.4",
-        "sandwich-stream": "^2.0.2"
+        "debug": "^4.0.1",
+        "minimist": "^1.2.0",
+        "module-alias": "^2.2.2",
+        "node-fetch": "^2.2.0",
+        "sandwich-stream": "^2.0.1",
+        "typegram": "^3.10.0"
       },
       "bin": {
-        "telegraf": "lib/cli.mjs"
+        "telegraf": "bin/telegraf"
       },
       "engines": {
-        "node": "^12.20.0 || >=14.13.1"
+        "node": ">=10"
       }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/typegram": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.12.0.tgz",
+      "integrity": "sha512-/VrU0sJv8BdOsBIpYT4w35C7dPg5YyKP6fLiYN9qYXRZ86TVIiw0ZypkzElTAfDVsJtJSluGAufUrcX7VRSIYQ==",
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "dotenv": "^17.2.3",
-    "lowdb": "^6.1.1",
-    "nanoid": "^5.1.6",
-    "telegraf": "^4.16.3"
+    "dotenv": "^16.4.5",
+    "nanoid": "^3.3.7",
+    "telegraf": "^3.38.0"
   }
 }

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,4 +1,4 @@
-﻿const path = require('path');
+const path = require('path');
 const fs = require('fs');
 
 const defaultData = {
@@ -23,23 +23,79 @@ const clone = (value) =>
     ? structuredClone(value)
     : JSON.parse(JSON.stringify(value));
 
+class JsonFileDb {
+  constructor(file, data) {
+    this.file = file;
+    this.data = data;
+  }
+
+  async read() {
+    try {
+      const content = await fs.promises.readFile(this.file, 'utf8');
+      if (!content.trim()) {
+        this.data = clone(defaultData);
+        await this.write();
+        return;
+      }
+
+      this.data = JSON.parse(content);
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        this.data = clone(defaultData);
+        await this.write();
+        return;
+      }
+
+      if (error instanceof SyntaxError) {
+        this.data = clone(defaultData);
+        await this.write();
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  async write() {
+    const directory = path.dirname(this.file);
+    await fs.promises.mkdir(directory, { recursive: true });
+    const payload = JSON.stringify(this.data, null, 2);
+    await fs.promises.writeFile(this.file, `${payload}\n`, 'utf8');
+  }
+}
+
 let dbPromise;
 
 async function ensureDb() {
-  const [{ Low }, { JSONFile }] = await Promise.all([
-    import('lowdb'),
-    import('lowdb/node'),
-  ]);
-
   const file = path.join(__dirname, '..', 'data', 'db.json');
   await fs.promises.mkdir(path.dirname(file), { recursive: true });
-  const adapter = new JSONFile(file);
-  const db = new Low(adapter, clone(defaultData));
-  await db.read();
-  if (!db.data) {
-    db.data = clone(defaultData);
+
+  let data = clone(defaultData);
+  let needsWrite = true;
+
+  try {
+    const content = await fs.promises.readFile(file, 'utf8');
+    if (content.trim()) {
+      data = JSON.parse(content);
+      needsWrite = false;
+    }
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      // File does not exist yet — will be created below.
+    } else if (error instanceof SyntaxError) {
+      // Corrupted JSON — reset to defaults and overwrite the file.
+      needsWrite = true;
+    } else {
+      throw error;
+    }
+  }
+
+  const db = new JsonFileDb(file, data);
+
+  if (needsWrite) {
     await db.write();
   }
+
   return db;
 }
 


### PR DESCRIPTION
## Summary
- replace the lowdb storage layer with an internal JSON file helper that works without ESM imports
- downgrade telegraf, nanoid and dotenv to versions that support Node 12
- refresh the lockfile to reflect the compatible dependency set

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_b_68dd80b82dc88328ad10c16a6a55b6bf